### PR TITLE
Feat: 저장소추가 버튼 눌렀을때 모달로 깃허브에서 로그인 한 유저의 소유 레포, 기여한 레포 목록 보여주는 기능 추가

### DIFF
--- a/app/(member)/commits/page.tsx
+++ b/app/(member)/commits/page.tsx
@@ -2,3 +2,25 @@ export default function CommitPage() {
     // TODO: 사이드바와 탭 부분은 공통 컴포넌트로 작성해서 각 페이지마다 넣기.
     return <div>CommitPage</div>;
 }
+
+// "use client";
+
+// import { useState } from "react";
+// import RepoSelectModal from "../components/RepoSelectModal";
+
+// export default function CommitPage() {
+//     const [open, setOpen] = useState(false);
+
+//     return (
+//         <div className="p-4">
+//             <button
+//                 onClick={() => setOpen(true)}
+//                 className="bg-blue-600 text-white px-4 py-2 rounded-md"
+//             >
+//                 저장소 추가
+//             </button>
+
+//             <RepoSelectModal open={open} onClose={() => setOpen(false)} />
+//         </div>
+//     );
+// }

--- a/app/(member)/components/RepoSelectModal.tsx
+++ b/app/(member)/components/RepoSelectModal.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { GitHubRepoDto } from "@/application/usecase/github/dto/GitHubRepoDto";
+import Image from "next/image";
+
+type Props = {
+    open: boolean;
+    onClose: () => void;
+};
+
+export default function RepoSelectModal({ open, onClose }: Props) {
+    const [repos, setRepos] = useState<GitHubRepoDto[]>([]);
+    const [selected, setSelected] = useState<Set<string>>(new Set());
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        if (!open) return;
+
+        const fetchRepos = async () => {
+            setLoading(true);
+            try {
+                const res = await fetch("/api/github/repos");
+                const data = await res.json();
+                setRepos(data);
+            } catch (err) {
+                alert("레포지토리를 불러오는 데 실패했습니다.");
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchRepos();
+    }, [open]);
+
+    const toggleRepo = (id: string) => {
+        setSelected((prev) => {
+            const copy = new Set(prev);
+            copy.has(id) ? copy.delete(id) : copy.add(id);
+            return copy;
+        });
+    };
+
+    if (!open) return null;
+
+    return (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+            <div className="bg-white p-6 rounded-xl max-w-2xl w-full shadow-lg">
+                <div className="flex justify-between items-center mb-1">
+                    <h2 className="text-xl font-bold">연동할 저장소 선택</h2>
+                    <button onClick={onClose}>
+                        <Image
+                            src="/x-gray.svg"
+                            alt="닫기"
+                            width={16}
+                            height={16}
+                            className="opacity-60 hover:opacity-100 transition"
+                        />
+                    </button>
+                </div>
+                <p className="text-xs text-gray-500 m-4">
+                    회고록을 작성할 GitHub 저장소를 선택해주세요. 선택한 저장소의 커밋 기록이 자동으로 동기화됩니다.
+                </p>
+
+                {loading ? (
+                    <p>불러오는 중...</p>
+                ) : (
+                    <ul className="max-h-[350px] overflow-y-auto divide-y">
+                        {repos.map((repo) => (
+                            <li
+                                key={repo.id}
+                                className="flex justify-between items-start p-4 border border-gray-200 rounded-lg"
+                            >
+                                <div className="flex flex-col gap-1 w-full">
+                                    <div className="flex items-start justify-between">
+                                        <div className="flex items-center gap-2 truncate">
+                                            <input
+                                                type="checkbox"
+                                                checked={selected.has(repo.id)}
+                                                onChange={() => toggleRepo(repo.id)}
+                                                className="mt-0.5"
+                                            />
+                                            <div className="flex items-center gap-2 font-semibold text-sm text-gray-900 truncate">
+                                                {repo.name}
+                                                <span className="bg-gray-100 text-yellow-500 text-xs px-2 py-0.5 rounded-md flex items-center gap-1 font-semibold">
+                                                    ⭐ {repo.stargazerCount}
+                                                </span>
+                                            </div>
+                                        </div>
+                                        <div className="text-xs text-gray-400 whitespace-nowrap">
+                                            Last updated: {repo.updatedAt.slice(0, 10)}
+                                        </div>
+                                    </div>
+                                    <p className="text-sm text-gray-500 truncate ml-6">
+                                        {repo.description || "설명이 없습니다."}
+                                    </p>
+                                    <p className="text-xs mt-1 flex items-center gap-1 text-gray-600 ml-6">
+                                        <span
+                                            className="inline-block w-2 h-2 rounded-full"
+                                            style={{ backgroundColor: repo.languageColor || "#999" }}
+                                        />
+                                        {repo.languageName || "언어 미상"}
+                                    </p>
+                                </div>
+                            </li>
+                        ))}
+                    </ul>
+                )}
+
+                <div className="mt-6 flex justify-end gap-2">
+                    <button onClick={onClose} className="text-sm px-4 py-2 rounded-md border border-gray-300">
+                        취소
+                    </button>
+                    <button
+                        className="bg-indigo-600 hover:bg-indigo-700 text-white text-sm px-4 py-2 rounded-md font-semibold"
+                    >
+                        {selected.size}개 저장소 연동하기
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/app/(member)/components/RepoSelectModal.tsx
+++ b/app/(member)/components/RepoSelectModal.tsx
@@ -65,11 +65,11 @@ export default function RepoSelectModal({ open, onClose }: Props) {
                 {loading ? (
                     <p>불러오는 중...</p>
                 ) : (
-                    <ul className="max-h-[350px] overflow-y-auto divide-y">
+                    <ul className="border-border-primary1 max-h-[350px] divide-y overflow-y-auto rounded-lg border">
                         {repos.map((repo) => (
                             <li
                                 key={repo.id}
-                                className="flex justify-between items-start p-4 border border-gray-200 rounded-lg"
+                                className="border-b-border-primary1 flex items-start justify-between p-4 last:border-b-0"
                             >
                                 <div className="flex flex-col gap-1 w-full">
                                     <div className="flex items-start justify-between">

--- a/app/api/github/repos/route.ts
+++ b/app/api/github/repos/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+import { FetchFromGithub } from "@/infra/repositories/github/GbRepoRepository";
+import { FetchRepos } from "@/application/usecase/github/FetchRepos";
+import { getToken } from "next-auth/jwt";
+
+export async function GET(req: NextRequest) {
+    const token = await getToken({ req });
+    const githubToken = token?.accessToken;
+
+    if (!githubToken) {
+        return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+    }
+
+    const repo = new FetchFromGithub();
+    const usecase = new FetchRepos(repo);
+    const repos = await usecase.execute(githubToken);
+
+    return NextResponse.json(repos);
+}

--- a/application/usecase/github/FetchRepos.ts
+++ b/application/usecase/github/FetchRepos.ts
@@ -1,0 +1,10 @@
+import { GithubRepoRepository } from "@/domain/repositories/GithubRepoRepository";
+import { GitHubRepoDto } from "./dto/GitHubRepoDto";
+
+export class FetchRepos {
+    constructor(private readonly repo: GithubRepoRepository) { }
+
+    async execute(token: string): Promise<GitHubRepoDto[]> {
+        return await this.repo.fetchAll(token);
+    }
+}

--- a/application/usecase/github/dto/GitHubRepoDto.ts
+++ b/application/usecase/github/dto/GitHubRepoDto.ts
@@ -1,0 +1,14 @@
+export class GitHubRepoDto {
+    constructor(
+        public id: string,
+        public name: string,
+        public nameWithOwner: string,
+        public url: string,
+        public isPrivate: boolean,
+        public description: string | null,
+        public updatedAt: string,
+        public stargazerCount: number,
+        public languageName?: string,
+        public languageColor?: string
+    ) { }
+}

--- a/domain/repositories/GithubRepoRepository.ts
+++ b/domain/repositories/GithubRepoRepository.ts
@@ -1,0 +1,5 @@
+import { GitHubRepoDto } from "@/application/usecase/github/dto/GitHubRepoDto";
+
+export interface GithubRepoRepository {
+    fetchAll(token: string): Promise<GitHubRepoDto[]>;
+}

--- a/infra/repositories/github/GbRepoRepository.ts
+++ b/infra/repositories/github/GbRepoRepository.ts
@@ -1,0 +1,106 @@
+import { GithubRepoRepository } from "@/domain/repositories/GithubRepoRepository";
+import { GitHubRepoDto } from "@/application/usecase/github/dto/GitHubRepoDto";
+
+export class FetchFromGithub implements GithubRepoRepository {
+    async fetchAll(token: string): Promise<GitHubRepoDto[]> {
+        const query = `
+      query {
+  viewer {
+    contributionsCollection {
+      commitContributionsByRepository(maxRepositories: 100) {
+        repository {
+          id
+          name
+          nameWithOwner
+          url
+          isPrivate
+          description
+          updatedAt
+          stargazerCount
+          primaryLanguage {
+            name
+            color
+          }
+        }
+      }
+      pullRequestContributionsByRepository(maxRepositories: 100) {
+        repository {
+          id
+          name
+          nameWithOwner
+          url
+          isPrivate
+          description
+          updatedAt
+          stargazerCount
+          primaryLanguage {
+            name
+            color
+          }
+        }
+      }
+    }
+    repositories(first: 100, ownerAffiliations: [OWNER]) {
+      nodes {
+        id
+        name
+        nameWithOwner
+        url
+        isPrivate
+        description
+        updatedAt
+        stargazerCount
+        primaryLanguage {
+          name
+          color
+        }
+      }
+    }
+  }
+}
+    `;
+
+        const res = await fetch("https://api.github.com/graphql", {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${token}`,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ query }),
+        });
+
+        if (!res.ok) throw new Error("GitHub 레포 불러오기 실패");
+
+        const json = await res.json();
+        const { contributionsCollection, repositories } = json.data.viewer;
+
+        const extractRepos = (arr: any[]) =>
+            arr.map((c: any) => {
+                const r = c.repository ?? c; // node or wrapped repository
+                return new GitHubRepoDto(
+                    r.id,
+                    r.name,
+                    r.nameWithOwner,
+                    r.url,
+                    r.isPrivate,
+                    r.description,
+                    r.updatedAt,
+                    r.stargazerCount,
+                    r.primaryLanguage?.name,
+                    r.primaryLanguage?.color
+                );
+            });
+
+        const fromCommits = extractRepos(contributionsCollection.commitContributionsByRepository);
+        const fromPRs = extractRepos(contributionsCollection.pullRequestContributionsByRepository);
+        const fromOwner = extractRepos(repositories.nodes);
+
+        const all = [...fromCommits, ...fromPRs, ...fromOwner];
+        const map = new Map<string, GitHubRepoDto>();
+        for (const repo of all) {
+            map.set(repo.nameWithOwner, repo);
+        }
+
+        return Array.from(map.values());
+    }
+}


### PR DESCRIPTION
# Pull Request

## 🔢 Issue Number

resolves #26 

## 📝 요약

저장소추가 버튼 눌렀을때 모달로 깃허브에서 로그인 한 유저의 소유 레포, 기여한 레포 목록 보여주는 기능 추가
체크하고 저장했을 때 repo에 저장하도록 다음 이슈에서 구현 예정

## 🛠️ PR 유형

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📋 변경사항 상세 설명

<!--- 필요한 경우 중요한 변경사항에 대해 더 자세히 설명해주세요 -->

## 🖼️ 스크린샷 및 데모
![20250513165144](https://github.com/user-attachments/assets/663bf1f2-4e38-401b-a6ab-6478952e5097)

## 👀 리뷰어

<!--- 이 PR의 리뷰를 요청할 담당자를 지정해주세요 -->
<!-- 예시: @username -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [X] 필요한 경우 문서를 업데이트했습니다.
- [X] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [X] 브랜치가 최신 상태의 메인 브랜치와 병합 가능합니다.

## 📢 특이사항

<!--- 리뷰어가 알아야 할 주의사항이나 특이점이 있다면 여기에 작성해주세요 -->
