### PR TITLE
Feat: 커밋페이지에서 로그인한 유저가 연동한 레포가 없으면 저장소추가모달 뜨도록 구현

### DIFF
--- a/app/(member)/commits/page.tsx
+++ b/app/(member)/commits/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import CommitCard from "@/app/(member)/commits/components/CommitCard";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import RepoSelectModal from "../components/RepoSelectModal";
 
 export default function CommitPage() {
     // TODO: 사이드바와 탭 부분은 공통 컴포넌트로 작성해서 각 페이지마다 넣기.
@@ -15,6 +16,22 @@ export default function CommitPage() {
         day: "numeric",
     }).format(now);
 
+    useEffect(() => {
+        const fetchUserRepos = async () => {
+            try {
+                const res = await fetch("/api/repos/user");
+                const repos = await res.json();
+                if (Array.isArray(repos) && repos.length === 0) {
+                    setOpen(true);
+                }
+            } catch (err) {
+                console.error("유저 저장소 확인 실패", err);
+            }
+        };
+
+        fetchUserRepos();
+    });
+
     const [open, setOpen] = useState(false);
 
     const branches = [
@@ -24,19 +41,22 @@ export default function CommitPage() {
     ];
 
     return (
-        <div className="border-border-primary1 rounded-lg border-1 bg-white">
-            <section className="border-border-primary1 flex items-center justify-between border-b p-4">
-                <h2 className="font-bold">최근 활동</h2>
-                <p className="text-text-secondary2 text-sm">{formattedDate}</p>
-            </section>
+        <>
+            <RepoSelectModal open={open} onClose={() => setOpen(false)} />
+            <div className="border-border-primary1 rounded-lg border-1 bg-white">
+                <section className="border-border-primary1 flex items-center justify-between border-b p-4">
+                    <h2 className="font-bold">최근 활동</h2>
+                    <p className="text-text-secondary2 text-sm">{formattedDate}</p>
+                </section>
 
-            <ul>
-                {/* CommitCard 의 props 로 커밋의 타입을 지정 - bugfix | feature | refactor */}
-                <CommitCard type="bugfix" />
-                <CommitCard type="feature" />
-                <CommitCard type="refactor" />
-                <CommitCard type="bugfix" />
-            </ul>
-        </div>
+                <ul>
+                    {/* CommitCard 의 props 로 커밋의 타입을 지정 - bugfix | feature | refactor */}
+                    <CommitCard type="bugfix" />
+                    <CommitCard type="feature" />
+                    <CommitCard type="refactor" />
+                    <CommitCard type="bugfix" />
+                </ul>
+            </div>
+        </>
     );
 }

--- a/app/(member)/commits/page.tsx
+++ b/app/(member)/commits/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import CommitCard from "@/app/(member)/commits/components/CommitCard";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import RepoSelectModal from "../components/RepoSelectModal";
 
 export default function CommitPage() {
@@ -17,6 +17,7 @@ export default function CommitPage() {
     }).format(now);
 
     useEffect(() => {
+        if (checkedOnceRef.current) return;
         const fetchUserRepos = async () => {
             try {
                 const res = await fetch("/api/repos/user");
@@ -30,9 +31,10 @@ export default function CommitPage() {
         };
 
         fetchUserRepos();
-    });
+    }, []);
 
     const [open, setOpen] = useState(false);
+    const checkedOnceRef = useRef(false);
 
     const branches = [
         { name: "frontend-app", icon: "branch-blue.svg" },


### PR DESCRIPTION
# Pull Request

## 🔢 Issue Number

resolves #45 

## 📝 요약

커밋페이지에서 로그인한 유저가 연동한 레포가 없으면 저장소추가모달 뜨도록 구현

## 🛠️ PR 유형

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📋 변경사항 상세 설명

<!--- 필요한 경우 중요한 변경사항에 대해 더 자세히 설명해주세요 -->

## 🖼️ 스크린샷 및 데모

<!--- UI 변경사항이 있는 경우 스크린샷이나 GIF/동영상을 첨부해주세요 -->

## 👀 리뷰어

<!--- 이 PR의 리뷰를 요청할 담당자를 지정해주세요 -->
<!-- 예시: @username -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [X] 필요한 경우 문서를 업데이트했습니다.
- [X] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [X] 브랜치가 최신 상태의 메인 브랜치와 병합 가능합니다.

## 📢 특이사항

<!--- 리뷰어가 알아야 할 주의사항이나 특이점이 있다면 여기에 작성해주세요 -->
