### PR TITLE
통계페이지에서 레포별로 작성된 회고록 수 변화량 안보이게 수정 + @

### DIFF
--- a/app/member/stats/components/StatsCard.tsx
+++ b/app/member/stats/components/StatsCard.tsx
@@ -7,6 +7,16 @@ export default function StatsCard({
     value: string;
     change: string;
 }) {
+    if (change === "hide") {
+        return (
+            <div className="border-border-primary1 h-30 rounded-xl border bg-white p-4 shadow-sm">
+                <p className="text-text-secondary2 mb-6 text-sm">{title}</p>
+                <div className="flex items-baseline">
+                    <span className="text-text-secondary1 text-2xl font-bold">{value}</span>
+                </div>
+            </div>
+        );
+    }
     const changeNumber = parseFloat(change.replace("%", ""));
     const isNegative = changeNumber < 0;
     const isZero = changeNumber === 0;

--- a/app/member/stats/components/WeeklyCommitChart.tsx
+++ b/app/member/stats/components/WeeklyCommitChart.tsx
@@ -85,9 +85,9 @@ export default function WeeklyCommitChart({ data }: Props) {
                     },
                 },
                 suggestedMax: Math.max(...data.map(d => d.count)) + 1.5,
-                // grid: {
-                //     display: false,
-                // },
+                grid: {
+                    display: false,
+                },
             },
             x: {
                 grid: {

--- a/app/member/stats/components/WeeklyCommitChart.tsx
+++ b/app/member/stats/components/WeeklyCommitChart.tsx
@@ -54,6 +54,11 @@ export default function WeeklyCommitChart({ data }: Props) {
 
     const options = {
         responsive: true,
+        layout: {
+            padding: {
+                top: 20,
+            },
+        },
         plugins: {
             legend: { display: false },
             tooltip: {

--- a/app/member/stats/page.tsx
+++ b/app/member/stats/page.tsx
@@ -118,7 +118,7 @@ export default function StatsPage() {
                 {totalMemoirs === null ? (
                     <StatsCardSkeleton />
                 ) : (
-                    <StatsCard title="작성된 회고록" value={totalMemoirs.toLocaleString()} change="15%" />
+                    <StatsCard title="작성된 회고록" value={totalMemoirs.toLocaleString()} change="hide" />
                 )}
             </div>
 


### PR DESCRIPTION
# Pull Request

## 🔢 Issue Number

resolves #101 

## 📝 요약

1. 통계페이지에서 레포별로 작성된 회고록 수 변화량 안보이게 수정
2. 통계페이지에서 커밋활동그래프 가로선 안보이게 수정
3. 통계페이지에서 커밋활동그래프 위로 숫자 삐져나가는 현상 수정

## 🛠️ PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📋 변경사항 상세 설명

<!--- 필요한 경우 중요한 변경사항에 대해 더 자세히 설명해주세요 -->

## 🖼️ 스크린샷 및 데모

<!--- UI 변경사항이 있는 경우 스크린샷이나 GIF/동영상을 첨부해주세요 -->

## 👀 리뷰어

<!--- 이 PR의 리뷰를 요청할 담당자를 지정해주세요 -->
<!-- 예시: @username -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 필요한 경우 문서를 업데이트했습니다.
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 브랜치가 최신 상태의 메인 브랜치와 병합 가능합니다.

## 📢 특이사항

<!--- 리뷰어가 알아야 할 주의사항이나 특이점이 있다면 여기에 작성해주세요 -->
