### PR TITLE
Fix: 커밋 카드 브랜치 명 표시 로직 수정

### DIFF
--- a/infra/repositories/github/GbCommitListRepository.ts
+++ b/infra/repositories/github/GbCommitListRepository.ts
@@ -1,3 +1,86 @@
+// import { GithubCommit } from "@/domain/entities/GithubCommitList";
+// import { GithubCommitListRepository } from "@/domain/repositories/GithubCommitListRepository";
+
+// export class GbCommitListRepository implements GithubCommitListRepository {
+//   async fetchCommitList({
+//     owner,
+//     repo,
+//     author,
+//     token,
+//     page = 1,
+//     perPage = 10,
+//   }: {
+//     owner: string;
+//     repo: string;
+//     author: string;
+//     token?: string;
+//     page?: number;
+//     perPage?: number;
+//   }): Promise<{ commits: GithubCommit[]; hasNextPage: boolean; totalCount: number; }> {
+//     const headers: Record<string, string> = {
+//       Accept: "application/vnd.github+json",
+//     };
+
+//     if (token) {
+//       headers.Authorization = `Bearer ${token}`;
+//     }
+
+//     // 1. 모든 브랜치 목록 조회
+//     const branchesRes = await fetch(
+//       `https://api.github.com/repos/${owner}/${repo}/branches`,
+//       { headers }
+//     );
+//     if (!branchesRes.ok) {
+//       const errorData = await branchesRes.json();
+//       throw new Error(
+//         `Failed to fetch branches: ${branchesRes.status} - ${errorData.message || "Unknown error"}`
+//       );
+//     }
+
+//     const branches = await branchesRes.json();
+
+//     let allCommits: GithubCommit[] = [];
+
+//     // 2. 각 브랜치별 커밋 조회
+//     for (const branch of branches) {
+//       const branchName = branch.name;
+
+//       const commitsRes = await fetch(
+//         `https://api.github.com/repos/${owner}/${repo}/commits?author=${author}&sha=${branchName}`,
+//         { headers }
+//       );
+//       if (!commitsRes.ok) {
+//         const errorData = await commitsRes.json();
+//         throw new Error(
+//           `Failed to fetch commits for branch ${branchName}: ${commitsRes.status} - ${errorData.message || "Unknown error"}`
+//         );
+//       }
+
+//       const commits = await commitsRes.json();
+//       const mappedCommits = commits.map((c: any) =>
+//         GithubCommit.fromJson({ ...c, branch: branchName })
+//       );
+//       allCommits.push(...mappedCommits);
+//     }
+
+//     // 3. 중복 제거 및 정렬
+//     const uniqueCommits = Array.from(
+//       new Map(allCommits.map(commit => [commit.sha, commit])).values()
+//     ).sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+
+//     // 4. 페이지네이션 처리
+//     const startIndex = (page - 1) * perPage;
+//     const endIndex = startIndex + perPage;
+//     const paginatedCommits = uniqueCommits.slice(startIndex, endIndex);
+
+//     return {
+//       commits: paginatedCommits,
+//       hasNextPage: endIndex < uniqueCommits.length,
+//       totalCount: uniqueCommits.length
+//     };
+//   }
+// }
+
 import { GithubCommit } from "@/domain/entities/GithubCommitList";
 import { GithubCommitListRepository } from "@/domain/repositories/GithubCommitListRepository";
 
@@ -25,7 +108,7 @@ export class GbCommitListRepository implements GithubCommitListRepository {
       headers.Authorization = `Bearer ${token}`;
     }
 
-    // 1. 모든 브랜치 목록 조회
+    // 1. 모든 브랜치 조회
     const branchesRes = await fetch(
       `https://api.github.com/repos/${owner}/${repo}/branches`,
       { headers }
@@ -36,12 +119,22 @@ export class GbCommitListRepository implements GithubCommitListRepository {
         `Failed to fetch branches: ${branchesRes.status} - ${errorData.message || "Unknown error"}`
       );
     }
-
     const branches = await branchesRes.json();
 
-    let allCommits: GithubCommit[] = [];
+    // 2. 디폴트 브랜치 조회
+    const repoRes = await fetch(`https://api.github.com/repos/${owner}/${repo}`, { headers });
+    if (!repoRes.ok) {
+      const errorData = await repoRes.json();
+      throw new Error(
+        `Failed to fetch repo info: ${repoRes.status} - ${errorData.message || "Unknown error"}`
+      );
+    }
+    const repoInfo = await repoRes.json();
+    const defaultBranch = repoInfo.default_branch;
 
-    // 2. 각 브랜치별 커밋 조회
+    // 3. 모든 커밋을 sha 기준으로 Map에 저장 (디폴트 브랜치 우선)
+    const commitMap = new Map<string, GithubCommit>();
+
     for (const branch of branches) {
       const branchName = branch.name;
 
@@ -57,18 +150,28 @@ export class GbCommitListRepository implements GithubCommitListRepository {
       }
 
       const commits = await commitsRes.json();
-      const mappedCommits = commits.map((c: any) =>
-        GithubCommit.fromJson({ ...c, branch: branchName })
-      );
-      allCommits.push(...mappedCommits);
+      for (const c of commits) {
+        const sha = c.sha;
+        const commit = GithubCommit.fromJson({ ...c, branch: branchName });
+
+        // 디폴트 브랜치면 무조건 우선 등록
+        if (branchName === defaultBranch) {
+          commitMap.set(sha, commit);
+        } else {
+          // 디폴트 브랜치가 아닌 경우, 해당 SHA가 없을 때만 추가
+          if (!commitMap.has(sha)) {
+            commitMap.set(sha, commit);
+          }
+        }
+      }
     }
 
-    // 3. 중복 제거 및 정렬
-    const uniqueCommits = Array.from(
-      new Map(allCommits.map(commit => [commit.sha, commit])).values()
-    ).sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+    // 4. 커밋들을 최신순으로 정렬
+    const uniqueCommits = Array.from(commitMap.values()).sort(
+      (a, b) => b.createdAt.getTime() - a.createdAt.getTime()
+    );
 
-    // 4. 페이지네이션 처리
+    // 5. 페이지네이션 처리
     const startIndex = (page - 1) * perPage;
     const endIndex = startIndex + perPage;
     const paginatedCommits = uniqueCommits.slice(startIndex, endIndex);
@@ -76,7 +179,7 @@ export class GbCommitListRepository implements GithubCommitListRepository {
     return {
       commits: paginatedCommits,
       hasNextPage: endIndex < uniqueCommits.length,
-      totalCount: uniqueCommits.length
+      totalCount: uniqueCommits.length,
     };
   }
 }


### PR DESCRIPTION
# Pull Request

## 🔢 Issue Number

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 예시 : resolves #1 -->

resolves #109 

## 📝 요약

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
중복 커밋 목록 필터링 로직을 수정하였습니다.
## 🛠️ PR 유형

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📋 변경사항 상세 설명

<!--- 필요한 경우 중요한 변경사항에 대해 더 자세히 설명해주세요 -->
문제 상황 : 커밋 목록 조회 시 커밋 카드에 브랜치명이 가장 최근에 생성된 브랜치가 표시되는 오류가 발생했습니다.
원인 : 중복된 커밋 목록을 필터링하는 경우, 가장 최근의 내역(가장 최근에 생성된 브랜치에 있는 중복 커밋)이 불러와지기 때문에 이런 오류가 발생했던 것으로 확인됩니다.
해결 방안: GbCommitListRepository 파일의 중복 커밋 제거 로직을 수정하였습니다 
=> 중복된 커밋은 Default branch 표시, 중복되지 않은 커밋은(push 가 된 경우만 확인 가능) 작업 중인 원격 브랜치 표시

## 🖼️ 스크린샷 및 데모

<!--- UI 변경사항이 있는 경우 스크린샷이나 GIF/동영상을 첨부해주세요 -->
### 가장 최근의 커밋 내역은 작업 중인 브랜치 표시, 중복 커밋은 default branch 표시
![image](https://github.com/user-attachments/assets/13944ae4-6aa2-4f37-8a8c-6cbec648d861)

## 👀 리뷰어

<!--- 이 PR의 리뷰를 요청할 담당자를 지정해주세요 -->
<!-- 예시: @username -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [X] 필요한 경우 문서를 업데이트했습니다.
- [X] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [X] 브랜치가 최신 상태의 메인 브랜치와 병합 가능합니다.

## 📢 특이사항

<!--- 리뷰어가 알아야 할 주의사항이나 특이점이 있다면 여기에 작성해주세요 -->
@pcw7 찬우님, 저를 일깨워주셔 감사합니다 🙇 