### PR TITLE
Fix : 통계페이지에서 작성한 회고록 레포 로그인한 사용자의 수만 나오는게 아니라 해당 레포에 대한 전체 회고록 수가 나오는 부분 수정하기

### DIFF
--- a/app/api/stats/memoirs/route.ts
+++ b/app/api/stats/memoirs/route.ts
@@ -6,13 +6,13 @@ import { PrMemoirRepository } from "@/infra/repositories/prisma/PrMemoirReposito
 
 export async function GET(req: NextRequest) {
   const token = await getToken({ req });
-  if (!token) return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+  if (!token?.id) return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
 
   const repoId = req.nextUrl.searchParams.get("repo");
   if (!repoId) return NextResponse.json({ message: "Missing repoId" }, { status: 400 });
 
   const usecase = new FetchMemoirCountUsecase(new PrMemoirRepository());
-  const count = await usecase.execute(new FetchMemoirCountDto(repoId));
+  const count = await usecase.execute(new FetchMemoirCountDto(repoId, token.id));
 
   return NextResponse.json({ totalMemoirs: count });
 }

--- a/application/usecase/memoir/FetchMemoirCountUsecase.ts
+++ b/application/usecase/memoir/FetchMemoirCountUsecase.ts
@@ -5,6 +5,6 @@ export class FetchMemoirCountUsecase {
     constructor(private repo: MemoirRepository) { }
 
     async execute(dto: FetchMemoirCountDto): Promise<number> {
-        return this.repo.countByRepoName(dto.repoId);
+        return this.repo.countByRepoName(dto.repoId, dto.userId);
     }
 }

--- a/application/usecase/memoir/dto/FetchMemoirCountDto.ts
+++ b/application/usecase/memoir/dto/FetchMemoirCountDto.ts
@@ -1,3 +1,3 @@
 export class FetchMemoirCountDto {
-  constructor(public repoId: string) { }
+  constructor(public repoId: string, public userId: string) { }
 }

--- a/domain/repositories/MemoirRepository.ts
+++ b/domain/repositories/MemoirRepository.ts
@@ -2,7 +2,7 @@ import { Memoir } from "@/prisma/generated/prisma";
 
 export interface MemoirRepository {
     findByUserId(userId: string, repoId?: string): Promise<any[]>;
-    countByRepoName(name: string): Promise<number>;
+    countByRepoName(name: string, userId: string): Promise<number>;
 
     create(data: {
         title: string;

--- a/infra/repositories/prisma/PrMemoirRepository.ts
+++ b/infra/repositories/prisma/PrMemoirRepository.ts
@@ -35,9 +35,10 @@ export class PrMemoirRepository implements MemoirRepository {
         });
     }
 
-    async countByRepoName(name: string): Promise<number> {
+    async countByRepoName(name: string, userId: string): Promise<number> {
         return await prisma.memoir.count({
             where: {
+                userId,
                 repo: {
                     name,
                 },


### PR DESCRIPTION
# Pull Request

## 🔢 Issue Number

resolves #136 

## 📝 요약

통계페이지에서 작성한 회고록 레포 로그인한 사용자의 수만 나오는게 아니라 해당 레포에 대한 전체 회고록 수가 나오는 부분 수정하기

## 🛠️ PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📋 변경사항 상세 설명

<!--- 필요한 경우 중요한 변경사항에 대해 더 자세히 설명해주세요 -->

## 🖼️ 스크린샷 및 데모

<!--- UI 변경사항이 있는 경우 스크린샷이나 GIF/동영상을 첨부해주세요 -->

## 👀 리뷰어

<!--- 이 PR의 리뷰를 요청할 담당자를 지정해주세요 -->
<!-- 예시: @username -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 필요한 경우 문서를 업데이트했습니다.
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 브랜치가 최신 상태의 메인 브랜치와 병합 가능합니다.

## 📢 특이사항

<!--- 리뷰어가 알아야 할 주의사항이나 특이점이 있다면 여기에 작성해주세요 -->
